### PR TITLE
Add the client and server middleware

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,6 +79,9 @@ Lint/UnmodifiedReduceAccumulator:
 Security/IoMethods:
   Enabled: true
 
+Style/AccessorGrouping:
+  EnforcedStyle: separated
+
 Style/ArgumentsForwarding:
   Enabled: true
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,13 +2,27 @@ PATH
   remote: .
   specs:
     sidekiq-global_id (0.1.0)
+      globalid
+      sidekiq
 
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (6.1.4.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     ast (2.4.2)
     coderay (1.1.3)
+    concurrent-ruby (1.1.9)
+    connection_pool (2.2.5)
     docile (1.4.0)
+    globalid (0.5.2)
+      activesupport (>= 5.0)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
     inch (0.8.0)
       pry
       sparkr (>= 0.2.0)
@@ -22,8 +36,10 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.6)
+    redis (4.5.0)
     regexp_parser (2.1.1)
     rexml (3.2.5)
     rubocop (1.22.1)
@@ -42,6 +58,10 @@ GEM
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)
     ruby-progressbar (1.11.0)
+    sidekiq (6.2.2)
+      connection_pool (>= 2.2.2)
+      rack (~> 2.0)
+      redis (>= 4.2.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -54,6 +74,8 @@ GEM
       tins (~> 1.0)
     tins (1.29.1)
       sync
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.1.0)
     yard (0.9.26)
     yard-doctest (0.1.17)
@@ -61,6 +83,7 @@ GEM
       yard
     yardstick (0.9.9)
       yard (~> 0.8, >= 0.8.7.2)
+    zeitwerk (2.4.2)
 
 PLATFORMS
   x86_64-linux

--- a/doctest_helper.rb
+++ b/doctest_helper.rb
@@ -18,3 +18,11 @@ end
 $LOAD_PATH.unshift File.expand_path("lib", __dir__)
 
 require "sidekiq/global_id"
+
+require_relative "test/support/assertions"
+require_relative "test/support/fakes"
+require_relative "test/support/sidekiq"
+
+User = Fakes::User
+
+User.new

--- a/doctest_helper.rb
+++ b/doctest_helper.rb
@@ -8,11 +8,6 @@ if ENV["COVERAGE"] || ENV["CI"]
   end
 
   SimpleCov.command_name "yard-doctest"
-
-  YARD::Doctest.after_run do
-    SimpleCov.set_exit_exception
-    SimpleCov.run_exit_tasks!
-  end
 end
 
 $LOAD_PATH.unshift File.expand_path("lib", __dir__)

--- a/lib/sidekiq/global_id.rb
+++ b/lib/sidekiq/global_id.rb
@@ -1,9 +1,39 @@
 # frozen_string_literal: true
 
+require "sidekiq"
+
+require_relative "global_id/client_middleware"
+require_relative "global_id/server_middleware"
 require_relative "global_id/version"
 
 module Sidekiq # :nodoc:
   # A gem for adding transparent GlobalID serialization to Sidekiq
+  #
+  # @example Using the serialization middleware
+  #
+  #   require "sidekiq/global_id"
+  #
+  #   Sidekiq.client_middleware do |chain|
+  #     chain.add Sidekiq::GlobalID::ClientMiddleware
+  #   end
+  #
+  #   Sidekiq.server_middleware do |chain|
+  #     chain.add Sidekiq::GlobalID::ServerMiddleware
+  #   end
+  #
+  #   class MyWorker
+  #     include Sidekiq::Worker
+  #
+  #     def perform(user)
+  #       raise ArgumentError if user.is_a?(User)
+  #     end
+  #   end
+  #
+  #   user = User.create!
+  #   MyWorker.perform_async(user)
+  #
+  #   job = MyWorker.jobs.last
+  #   job["args"] == [String(user.to_global_id)] #=> true
   module GlobalID
   end
 end

--- a/lib/sidekiq/global_id/client_middleware.rb
+++ b/lib/sidekiq/global_id/client_middleware.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative "serialization"
+
+module Sidekiq
+  module GlobalID
+    # A simple Sidekiq client middleware that serializes arguments as GlobalIDs
+    class ClientMiddleware
+      using Serialization
+
+      # Serializes all eligible positional arguments as GlobalIDs
+      #
+      # @api private
+      #
+      # @yieldparam _worker [String] - the class name of the worker performing the work
+      # @yieldparam job [Array] - the job arguments
+      # @yieldparam _queue [String] - the queue in which the job was enqueued
+      # @yieldparam _pool [ConnectionPool<Redis::Client>] - the pool of Redis connections
+      #
+      # @return [void]
+      def call(_worker, job, _queue, _pool)
+        job["args"].map!(&:serialize)
+        yield
+      end
+    end
+  end
+end

--- a/lib/sidekiq/global_id/serialization.rb
+++ b/lib/sidekiq/global_id/serialization.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+module Sidekiq
+  module GlobalID
+    # A refinement that defines how to [de]serialize Sidekiq arguments as GlobalIDs
+    #
+    # To make the logic easier to understand, this refinement houses all of the
+    # specializations for both serialization and deserialization from GlobalIDs for
+    # all types of arguments that you may find in Sidekiq arguments. This allows the
+    # middleware to remain simple even as we add support for different types of
+    # objects.
+    #
+    # @api private
+    module Serialization
+      refine Enumerable do
+        def deserialize
+          map!(&:deserialize)
+        end
+
+        def serialize
+          map(&:serialize)
+        end
+      end
+
+      refine Hash do
+        def deserialize
+          transform_keys!(&:deserialize)
+          transform_values!(&:deserialize)
+          self
+        end
+
+        def serialize
+          transform_keys!(&:serialize)
+          transform_values!(&:serialize)
+          self
+        end
+      end
+
+      refine Object do
+        def deserialize
+          self
+        end
+
+        def serialize
+          return self unless respond_to?(:to_global_id)
+
+          String(to_global_id)
+        end
+      end
+
+      refine String do
+        def deserialize
+          return self unless start_with?("gid://")
+
+          ::GlobalID::Locator.locate self
+        end
+
+        def serialize
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/sidekiq/global_id/server_middleware.rb
+++ b/lib/sidekiq/global_id/server_middleware.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require_relative "serialization"
+
+module Sidekiq
+  module GlobalID
+    # A simple Sidekiq server middleware that deserializes GlobalIDs as positional arguments.
+    class ServerMiddleware
+      using Serialization
+
+      # Deserializes all eligible positional arguments from GlobalIDs
+      #
+      # @api private
+      #
+      # @yieldparam _worker [String] - the class name of the worker performing the work
+      # @yieldparam job [Array] - the job arguments
+      # @yieldparam _queue [String] - the queue in which the job was enqueued
+      #
+      # @return [void]
+      def call(_worker, job, _queue)
+        job["args"].map!(&:deserialize)
+        yield
+      end
+    end
+  end
+end

--- a/sidekiq-global_id.gemspec
+++ b/sidekiq-global_id.gemspec
@@ -22,4 +22,7 @@ Gem::Specification.new do |spec|
   spec.files += %w[sidekiq-global_id.gemspec]
   spec.files += Dir["lib/**/*.rb"]
   spec.require_paths = ["lib"]
+
+  spec.add_dependency "globalid"
+  spec.add_dependency "sidekiq"
 end

--- a/test/sidekiq/global_id/client_middleware_test.rb
+++ b/test/sidekiq/global_id/client_middleware_test.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Sidekiq
+  module GlobalID
+    class ClientMiddlewareTest < Minitest::Test
+      include Assertions
+
+      class TestWorker
+        include Sidekiq::Worker
+
+        def perform(_user, _name = "foo", _opts = {}, _array = []); end
+      end
+
+      def setup
+        @user = Fakes::User.new
+      end
+
+      def teardown
+        TestWorker.clear
+      end
+
+      attr_reader :user
+
+      def test_serializing_positional_arguments
+        enqueue(user)
+
+        job = TestWorker.jobs.first
+        arg = job["args"].first
+
+        assert arg.start_with?("gid://")
+      end
+
+      def test_serializing_arrays_of_models
+        enqueue(user, "Bilbo Baggins", { user: user }, [user, user])
+
+        job = TestWorker.jobs.first
+        args = job["args"].last
+
+        args.each { |arg| assert arg.start_with?("gid://") }
+      end
+
+      def test_no_change_to_normal_strings
+        enqueue(user, "Bilbo Baggins")
+
+        job = TestWorker.jobs.first
+        arg = job["args"][1]
+
+        assert_equal "Bilbo Baggins", arg
+      end
+
+      def test_serializing_options_hashes
+        enqueue(user, "Bilbo Baggins", { user: user, user => "1" })
+
+        job = TestWorker.jobs.first
+        options = job.dig("args", 2)
+        global_id_key = options.fetch("user")
+
+        assert global_id_key.start_with?("gid://")
+        assert options.key?(String(user.to_global_id))
+      end
+
+      private
+
+      def enqueue(*args)
+        assert_change -> { TestWorker.jobs.size }, from: 0, to: 1 do
+          TestWorker.perform_async(*args)
+        end
+      end
+    end
+  end
+end

--- a/test/sidekiq/global_id/server_middleware_test.rb
+++ b/test/sidekiq/global_id/server_middleware_test.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Sidekiq
+  module GlobalID
+    class ServerMiddlewareTest < Minitest::Test
+      def setup
+        @user = Fakes::User.new
+        @middleware = ServerMiddleware.new
+      end
+
+      attr_reader :middleware
+      attr_reader :user
+
+      def test_deserializing_positional_arguments
+        job = { "args" => [String(user.to_gid)] }
+
+        call_middleware job
+
+        assert_equal user, job["args"].first
+      end
+
+      def test_deserializing_global_id_arrays
+        job = { "args" => [[String(user.to_gid), String(user.to_gid)]] }
+
+        call_middleware job
+
+        assert_equal [user, user], job["args"].first
+      end
+
+      def test_no_change_to_integers
+        job = { "args" => [1] }
+
+        call_middleware job
+
+        assert_equal [1], job["args"]
+      end
+
+      def test_no_change_to_normal_strings
+        job = { "args" => [String(user.to_gid), "Bilbo Baggins"] }
+
+        call_middleware job
+
+        assert_equal user, job["args"][0]
+        assert_equal "Bilbo Baggins", job["args"][1]
+      end
+
+      def test_serializing_options_hashes
+        gid = String(user.to_gid)
+        job = { "args" => [gid, "Bilbo Baggins", { "user" => gid, gid => "1" }] }
+
+        call_middleware job
+        reloaded_user, _name, opts = job["args"]
+
+        assert_equal user, reloaded_user
+        assert user, opts.fetch("user")
+        assert opts.key?(user)
+      end
+
+      def call_middleware(job)
+        middleware.call("MyWorker", job, "default", &-> {})
+      end
+    end
+  end
+end

--- a/test/support/assertions.rb
+++ b/test/support/assertions.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Helper assertions for writing easy-to-understand tests
+module Assertions
+  # Checks whether a change occurs in the value returned by a callable
+  def assert_change(callable, from: :__not_given__, to: :__not_given__)
+    raise ArgumentError, "`assert_change' requires a block" unless block_given?
+
+    before = callable.call
+    check_before(before, from)
+
+    yield
+
+    after = callable.call
+    check_after(after, to)
+
+    check_for_change(from, to)
+  end
+
+  private
+
+  def check_before(before, from)
+    return if from == :__not_given__
+
+    assert_equal(
+      before,
+      from,
+      "expected to start at #{from.inspect}, but started at #{before.inspect}"
+    )
+  end
+
+  def check_after(after, to)
+    return if to == :__not_given__
+
+    assert_equal(
+      after,
+      to,
+      "expected to change to #{to.inspect}, but was #{after.inspect}"
+    )
+  end
+
+  def check_for_change(from, to)
+    return unless from == to && from == :__not_given__
+
+    refute_equal(
+      before,
+      after,
+      "expected to change, but remained #{from.inspect}"
+    )
+  end
+end

--- a/test/support/fakes.rb
+++ b/test/support/fakes.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require "global_id"
+
+GlobalID.app = :testing
+
+module Fakes
+  class User
+    include GlobalID::Identification
+
+    def self.all
+      instances.values
+    end
+
+    def self.find(id)
+      id = id.to_i
+      instances.fetch(id)
+    end
+
+    def self.instances
+      @instances ||= {}
+    end
+
+    def self.next_id
+      current_max = instances.keys.max || 0
+      current_max.succ
+    end
+
+    class << self
+      alias create! new
+    end
+
+    def initialize(id: self.class.next_id)
+      id = id.to_i
+      @id = id
+      self.class.instances[id] = self
+    end
+
+    attr_reader :id
+  end
+end

--- a/test/support/sidekiq.rb
+++ b/test/support/sidekiq.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require "sidekiq"
+require "sidekiq/testing"
+
+Sidekiq.client_middleware do |chain|
+  chain.add Sidekiq::GlobalID::ClientMiddleware
+end
+
+Sidekiq.server_middleware do |chain|
+  chain.add Sidekiq::GlobalID::ServerMiddleware
+end
+
+Sidekiq::Testing.fake!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,4 +19,8 @@ end
 
 require "sidekiq/global_id"
 
+require_relative "support/assertions"
+require_relative "support/fakes"
+require_relative "support/sidekiq"
+
 require "minitest/autorun"


### PR DESCRIPTION
To make the handling of GlobalID-compatible objects truly transparent, we need to handle the logic within Sidekiq middleware. Middleware make it so you cannot forget to include a module to handle the serialization or remember the scheme that a worker uses to look up an object.

This iteration of the middleware handles everything except for Hashes with keys or values that are GlobalID-compatible.