### PR TITLE
Add all supported Rubies to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,11 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - 3.0.2
+          - 2.6
+          - 2.7
+          - '3.0'
+          - jruby-9.2.19.0
+          - jruby-9.3.1.0
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         ruby:
           - 2.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
     concurrent-ruby (1.1.9)
     connection_pool (2.2.5)
     docile (1.4.0)
+    ffi (1.15.4-java)
     globalid (0.5.2)
       activesupport (>= 5.0)
     i18n (1.8.10)
@@ -36,6 +37,10 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry (0.14.1-java)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+      spoon (~> 0.0)
     rack (2.2.3)
     rainbow (3.0.0)
     rake (13.0.6)
@@ -69,6 +74,8 @@ GEM
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     sparkr (0.4.1)
+    spoon (0.0.6)
+      ffi
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
@@ -86,6 +93,9 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  universal-java-1.8
+  universal-java-11
+  universal-java-16
   x86_64-linux
 
 DEPENDENCIES

--- a/README.md
+++ b/README.md
@@ -54,7 +54,6 @@ So you’re interested in contributing to sidekiq-global_id? Check out our [cont
 
 This library aims to support and is [tested against][actions] the following Ruby versions:
 
-* Ruby 2.5
 * Ruby 2.6
 * Ruby 2.7
 * Ruby 3.0

--- a/lib/sidekiq/global_id/serialization.rb
+++ b/lib/sidekiq/global_id/serialization.rb
@@ -12,13 +12,15 @@ module Sidekiq
     #
     # @api private
     module Serialization
-      refine Enumerable do
-        def deserialize
-          map!(&:deserialize)
-        end
+      [Array, Enumerable].each do |refineable|
+        refine refineable do
+          def deserialize
+            map!(&:deserialize)
+          end
 
-        def serialize
-          map(&:serialize)
+          def serialize
+            map(&:serialize)
+          end
         end
       end
 


### PR DESCRIPTION
We aim to support all versions of Ruby that still receive updates. The MRI core team [supports back to 2.6][1] and, as far as I can tell, JRuby [still supports 9.2][2], though that document appears out-of-date.

[1]: https://www.ruby-lang.org/en/downloads/branches/
[2]: https://github.com/jruby/jruby/blob/master/SECURITY.md