### PR TITLE
Add a client middleware benchmark

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,10 @@ group :development do
     end
   end
 
+  group :benchmarking do
+    gem "benchmark-ips"
+  end
+
   group :linting do
     gem "inch", "~> 0.8.0"
     gem "rubocop", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
     ast (2.4.2)
+    benchmark-ips (2.9.2)
     builder (3.2.4)
     coderay (1.1.3)
     concurrent-ruby (1.1.9)
@@ -152,6 +153,7 @@ PLATFORMS
 DEPENDENCIES
   activerecord
   activerecord-jdbcsqlite3-adapter
+  benchmark-ips
   inch (~> 0.8.0)
   minitest (~> 5.0)
   pry

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,26 @@
+# sidekiq-global_id benchmarks
+
+To run any of the benchmarks in this directory, you will need a working Redis instance on the local host. To make this easier, we include a Docker Compose file that will allow you to easily run Redis.
+
+## Running Redis
+
+To use Docker Compose, run the following in a terminal window:
+
+    cd benchmarks/
+    docker-compose up
+
+To run Redis with only Docker, run:
+
+    docker run --rm -it -p 6379:6379 redis:6-alpine
+
+Or with Podman:
+
+    podman run --rm -it -p 6379:6379 docker.io/library/redis:6-alpine
+
+## Running a benchmark
+
+The benchmark scripts are pure Ruby scripts. You can run them with `bundle exec ruby`, for instance:
+
+    bundle exec ruby benchmarks/client.rb
+
+Since the gem works via middleware, we need to configure the middleware or not to benchmark them. We do this by using benchmark-ips' hold functionality, so **run the benchmark twice** to generate a comparison.

--- a/benchmarks/client.rb
+++ b/benchmarks/client.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+$LOAD_PATH.unshift(File.join(__dir__, "..", "lib"))
+
+require "benchmark/ips"
+require "fileutils"
+require "sidekiq/global_id"
+
+require_relative "../test/support/fakes"
+
+tmp_dir = File.join(__dir__, "..", "tmp").tap(&FileUtils.method(:mkdir_p))
+hold_file = File.join(tmp_dir, "client.jsonl")
+
+# Enable the middleware on the second run
+if File.exist?(hold_file)
+  Sidekiq.client_middleware do |chain|
+    chain.add Sidekiq::GlobalID::ClientMiddleware
+  end
+end
+
+# A no-op worker for benchmarking the client middleware
+class MyWorker
+  include Sidekiq::Worker
+
+  def perform(user_or_id); end
+end
+
+user = Fakes::User.new
+
+Benchmark.ips do |bench|
+  bench.report("without GlobalID") { MyWorker.perform_async(user.id) }
+  bench.report("with GlobalID") { MyWorker.perform_async(user) }
+
+  bench.compare!
+  bench.hold!(hold_file)
+end

--- a/benchmarks/docker-compose.yml
+++ b/benchmarks/docker-compose.yml
@@ -1,0 +1,9 @@
+---
+version: "3.3"
+
+services:
+  redis:
+    image: redis:6-alpine
+    container_name: redis
+    ports:
+      - 6379:6379


### PR DESCRIPTION
This benchmark shows a ~25-33% performance penalty over bare Sidekiq. Depending on the performance characteristics of your application, this may or may not be acceptable.